### PR TITLE
Downgrade to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-bookworm
+FROM python:3.11-bookworm
 
 COPY requirements.txt /requirements.txt
 COPY post_dr_comment.py /post_dr_comment.py


### PR DESCRIPTION
We're seeing this error: https://github.com/python/cpython/issues/120788

In some runs, so this commit downgrades Python to 3.11, as all reports of that bug seem to be from 3.12.