### PR TITLE
Raise a clearer error if design review number is not set

### DIFF
--- a/post_dr_comment.py
+++ b/post_dr_comment.py
@@ -168,6 +168,11 @@ def main():
 
     args = parser.parse_args()
 
+    if not args.design_review_number.isdigit():
+        raise ValueError(
+            "Design review number is either not set or not a number; this run may not be on a pull request event?"
+        )
+
     logger.setLevel(args.log_level.upper())
     client = AllSpice(
         args.allspice_hub_url,


### PR DESCRIPTION
If `post-dr-comment` is called in a run which is not on a design review, the DR number is not set in the context. This previously led to an incomprehensible error. This commit checks early to make sure the design review number is set and errors with an explanation if it isn't.